### PR TITLE
Added black/whitelists for attributes on models

### DIFF
--- a/lib/hario.rb
+++ b/lib/hario.rb
@@ -4,6 +4,10 @@ require "hario/behaviours/pluck"
 
 module Hario
   module Filterable
+    HARIO_APPLY_TYPES = %w( filters pluck ).map(&:to_sym)
+
+    attr_reader :hario_attributes_list
+
     def search(filters, pluck = nil)
       s = all
       s = s.apply_filters(filters) if filters
@@ -32,5 +36,22 @@ module Hario
     def hash_pluck(*keys)
       pluck(*keys).map{ |vals| Hash[keys.zip(Array(vals))] }
     end
+
+    def hario_attributes(types, only: nil, except: nil)
+      @hario_attributes_list ||= {}
+      Array.wrap(types).each do |t|
+        raise_if_not_hario_type!(t)
+        @hario_attributes_list[t] =
+          { only: Array.wrap(only), except: Array.wrap(except) }
+      end
+    end
+
+    private
+      def raise_if_not_hario_type!(type)
+        unless HARIO_APPLY_TYPES.include?(type)
+          raise ArgumentError, "#{type} is not one of " \
+            "#{HARIO_APPLY_TYPES.map(&:inspect).join(', ')}"
+        end
+      end
   end
 end

--- a/lib/hario/behaviours/filter.rb
+++ b/lib/hario/behaviours/filter.rb
@@ -16,7 +16,6 @@ module Hario
       parse_filters
     end
 
-    InvalidAttributeError = Class.new(RuntimeError)
     InvalidValueError     = Class.new(RuntimeError)
 
     private
@@ -49,6 +48,7 @@ module Hario
           end_model = @klass
         end
 
+        raise_if_unlisted_attribute!(:filters, end_model, attribute)
         raise_if_invalid_attribute!(attribute, end_model)
 
         case operator

--- a/lib/hario/behaviours/pluck.rb
+++ b/lib/hario/behaviours/pluck.rb
@@ -20,10 +20,16 @@ module Hario
 
         ns, no_ns = @pluck.partition{ |p| p.include?('.') }
 
-        no_ns.each{ |p| @pluck_clause << [@klass.table_name, p].join('.') }
+        no_ns.each do |p|
+          raise_if_unlisted_attribute!(:pluck, @klass, p)
+          @pluck_clause << [@klass.table_name, p].join('.')
+        end
 
         ns.each do |p|
           association_chain, attribute = parse_namespace(p)
+
+          end_model = end_model_from_association_chain(association_chain)
+          raise_if_unlisted_attribute!(:pluck, end_model, attribute)
 
           nested_associations = (association_chain.dup << {}).reverse.inject { |v, key| { key => v } }
           @join_clause.deep_merge!(nested_associations)

--- a/lib/hario/behaviours/utils.rb
+++ b/lib/hario/behaviours/utils.rb
@@ -1,4 +1,6 @@
 module ParserUtils
+  InvalidAttributeError = Class.new(RuntimeError)
+
   def table_name_from_association_chain(association_chain)
     end_model_from_association_chain(association_chain).table_name
   end
@@ -11,5 +13,17 @@ module ParserUtils
     end
     
     head
+  end
+
+  def raise_if_unlisted_attribute!(type, model_class, attribute)
+    return unless model_class.respond_to?(:hario_attributes_list)
+    return unless model_class.hario_attributes_list
+    lists = model_class.hario_attributes_list[type]
+    return unless lists
+    attribute = attribute.to_sym
+    if (lists[:except].present? &&  lists[:except].include?(attribute)) ||
+       (lists[:only  ].present? && !lists[:only  ].include?(attribute))
+      raise InvalidAttributeError, "#{attribute} is forbidden"
+    end
   end
 end

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -74,4 +74,20 @@ class FilterTest < Hario::Test
       Product.search(filters)
     end
   end
+
+  def test_hidden_column_filter
+    filters = { 'hidden_column.equals' => 5 }
+
+    assert_raises Hario::FilterParser::InvalidAttributeError do
+      Product.search(filters)
+    end
+  end
+
+  def test_hidden_column_filter_with_join
+    filters = { 'products.hidden_column.equals' => 5 }
+
+    assert_raises Hario::FilterParser::InvalidAttributeError do
+      Brand.search(filters)
+    end
+  end
 end

--- a/test/models.rb
+++ b/test/models.rb
@@ -9,6 +9,8 @@ end
 class Product < ActiveRecord::Base
   extend Hario::Filterable
 
+  hario_attributes [:filters, :pluck], except: :hidden_column
+
   belongs_to :brand
   belongs_to :category, class_name: "ProductCategory"
 end

--- a/test/pluck_test.rb
+++ b/test/pluck_test.rb
@@ -16,4 +16,16 @@ class PluckTest < Hario::Test
     assert_equal ["id", "name", "brands.name"], products.flat_map(&:keys).uniq,
         "Pluck not returning correct attributes with association pluck"
   end
+
+  def test_hidden_column_pluck
+    assert_raises Hario::PluckParser::InvalidAttributeError do
+      Product.search(nil, %w( hidden_column ))
+    end
+  end
+
+  def test_hidden_column_pluck_with_join
+    assert_raises Hario::PluckParser::InvalidAttributeError do
+      Brand.search(nil, %w( products.hidden_column ))
+    end
+  end
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -8,6 +8,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :name, :string
     t.column :category_id, :integer
     t.column :brand_id, :integer
+    t.column :hidden_column, :integer
     t.timestamps null: false
   end
 


### PR DESCRIPTION
- Can change access to attributes by filters and plucking, e.g.:
  - hario_attributes :pluck, opts
  - hario_attributes [:pluck, :filters], opts
- opts must be a hash containing only: and/or except: with a list
  of the attributes to black/whitelist
