### PR TITLE
Support comma-separated strings for 'in' operator

### DIFF
--- a/lib/hario/behaviours/filter.rb
+++ b/lib/hario/behaviours/filter.rb
@@ -52,7 +52,11 @@ module Hario
         raise_if_invalid_attribute!(attribute, end_model)
 
         case operator
-        when :equals, :in
+        when :equals
+          condition = { attribute => value }
+          condition = { attribute_table => condition } if attribute_table
+        when :in
+          value = value.split(',').map(&:strip) if value.is_a?(String)
           condition = { attribute => value }
           condition = { attribute_table => condition } if attribute_table
         when :is


### PR DESCRIPTION
Parse comma-separated string values into arrays for the 'in' filter
  operator, enabling SQL IN queries with multiple values from string input.